### PR TITLE
Add the ability to get the schedule from the liveschedule endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,5 +142,32 @@ announcements = cl.get_announcements(token["access_token"])
 print(announcements)
 ```
 
+### Announcements
+
+```python
+Client.get_liveschedule()
+```
+
+Params: 
+```
+Token: String ? Access_token you get from the Client.Authenticate() function
+Week: String ? The ISO-week for which you want to request the schedule
+Usercode: String ? The code of the student you want to request the schedule of 
+```
+
+Result:
+
+```
+Enrollments: dict()
+```
+
+Demo:
+
+```python
+usercode = cl.get_user(token["access_token"])["response"]["data"][0]["code"]
+enrollments = cl.get_liveschedule(token["access_token"], "202150", usercode) # Requests week 50 of the year 2021
+print(enrollments)
+```
+
 # License
 [MIT](https://github.com/wouter173/zermelo.py/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ announcements = cl.get_announcements(token["access_token"])
 print(announcements)
 ```
 
-### Announcements
+### Enrollments
 
 ```python
 Client.get_liveschedule()

--- a/zermelo/client.py
+++ b/zermelo/client.py
@@ -1,95 +1,109 @@
 import requests
 import json
 
+
 class Client():
-  def __init__(self, school=""):
+    def __init__(self, school=""):
+        self.session = requests.Session()
 
-    self.session = requests.Session()
+        if school != "":
+            self.endpoint = "https://{}.zportal.nl/api".format(school)
+        else:
+            raise ValueError("School is not defined.")
 
-    if school != "":
-      self.endpoint = "https://{}.zportal.nl/api".format(school)
-    else: 
-      raise ValueError("School is not defined.")
-  
+    def authenticate(self, code=""):
+        if code == "":
+            raise ValueError("Code is not defined.")
 
-  def authenticate(self, code=""):
+        url = "{}/v3/oauth/token".format(self.endpoint)
+        data = {
+            "grant_type": "authorization_code",
+            "code": code.replace(" ", "")
+        }
+        res = self.session.post(url=url, data=data)
 
-    if code == "":
-      raise ValueError("Code is not defined.")
+        if res.status_code == 400:
+            raise ValueError("Parsed code is not active.")
+        elif res.status_code == 404:
+            raise ValueError("School does not exist.")
+        elif res.status_code == 200:
+            return json.loads(res.text)
 
-    url = "{}/v3/oauth/token".format(self.endpoint)
-    data = {
-      "grant_type": "authorization_code",
-      "code": code.replace(" ", "") 
-    }
-    res = self.session.post(url = url, data = data)
+    def get_user(self, token=""):
+        if token == "":
+            raise ValueError("Token is not defined.")
 
-    if res.status_code == 400:
-      raise ValueError("Parsed code is not active.")
-    elif res.status_code == 404:
-      raise ValueError("School does not exist.")
-    elif res.status_code == 200:
-      return json.loads(res.text)
+        url = "{}/v3/users/~me".format(self.endpoint)
+        params = {"access_token": token}
 
+        res = self.session.get(url=url, params=params)
 
-  def get_user(self, token=""):
+        if res.status_code == 401:
+            raise ValueError("Token not active.")
+        elif res.status_code == 200:
+            return json.loads(res.text)
 
-    if token == "":
-      raise ValueError("Token is not defined.")
+    def get_appointments(self, token="", start_unix="", end_unix=""):
+        if token == "":
+            raise ValueError("Token is not defined.")
+        elif start_unix == "":
+            raise ValueError("Start unix timestamp is not defined.")
+        elif end_unix == "":
+            raise ValueError("End unix timestamp is not defined.")
 
-    url = "{}/v3/users/~me".format(self.endpoint)
-    params = {"access_token": token}
+        url = "{}/v3/appointments/".format(self.endpoint)
+        params = {
+            "user": "~me",
+            "start": start_unix,
+            "end": end_unix,
+            "access_token": token
+        }
 
-    res = self.session.get(url = url, params = params)
-    
-    if res.status_code == 401:
-      raise ValueError("Token not active.")
-    elif res.status_code == 200:
-      return json.loads(res.text)
-  
+        res = self.session.get(url=url, params=params)
 
-  def get_appointments(self, token="", start_unix="", end_unix=""):
+        if res.status_code == 403:
+            raise ValueError(
+                "Start unix timestamp and / or end unix timestamp make no sense.")
+        elif res.status_code == 401:
+            raise ValueError("Token not active.")
+        elif res.status_code == 200:
+            return json.loads(res.text)
 
-    if token == "":
-      raise ValueError("Token is not defined.")
-    elif start_unix == "":
-      raise ValueError("Start unix timestamp is not defined.")
-    elif end_unix == "":
-      raise ValueError("End unix timestamp is not defined.")
+    def get_announcements(self, token=""):
+        if token == "":
+            raise ValueError("Token is not defined.")
 
-    url = "{}/v3/appointments/".format(self.endpoint)
-    params = {
-      "user": "~me",
-      "start": start_unix,
-      "end": end_unix,
-      "access_token": token
-    }
+        url = "{}/v2/announcements".format(self.endpoint)
+        params = {
+            "user": "~me",
+            "access_token": token
+        }
 
-    res = self.session.get(url = url, params = params)
+        res = self.session.get(url=url, params=params)
 
-    if res.status_code == 403:
-      raise ValueError("Start unix timestamp and / or end unix timestamp make no sense.")
-    elif res.status_code == 401:
-      raise ValueError("Token not active.")
-    elif res.status_code == 200:
-      return json.loads(res.text)
+        if res.status_code == 401:
+            raise ValueError("Token not active.")
+        elif res.status_code == 200:
+            return json.loads(res.text)
 
+    def get_liveschedule(self, token="", week: str = None, usercode: str = None):
+        if token == "":
+            raise ValueError("Token is not defined.")
 
-  def get_announcements(self, token=""):
+        if week == None:
+            raise ValueError("Week is not defined.")
 
-    if token == "":
-      raise ValueError("Token is not defined.")
-    
+        if usercode == None:
+            raise ValueError("Usercode is not defined.")
 
-    url = "{}/v2/announcements".format(self.endpoint)
-    params = {
-      "user": "~me",
-      "access_token": token
-    }
+        url = f"{self.endpoint}/v1/liveschedule?student={usercode}&week={week}"
+        params = {
+            "access_token": token
+        }
 
-    res = self.session.get(url = url, params = params)
+        res = self.session.get(url, params=params)
 
-    if res.status_code == 401:
-      raise ValueError("Token not active.")
-    elif res.status_code == 200:
-      return json.loads(res.text)
+        if res.status_code == 401:
+            raise ValueError("Token not active.")
+        elif res.status_code == 200:
+            return json.loads(res.text)

--- a/zermelo/client.py
+++ b/zermelo/client.py
@@ -96,7 +96,7 @@ class Client():
         if usercode == None:
             raise ValueError("Usercode is not defined.")
 
-        url = f"{self.endpoint}/v1/liveschedule?student={usercode}&week={week}"
+        url = f"{self.endpoint}/v3/liveschedule?student={usercode}&week={week}"
         params = {
             "access_token": token
         }


### PR DESCRIPTION
This PR adds the method `Client.get_liveschedule`. 
You can read more about it here: [Zermelo API docs](https://support.zermelo.nl/guides/developers-api/liveschedule#liveschedule_background). 
My autoformatter in VSCode also automatically formatted the rest of the code, if this is a problem I'll revert that. 
If there are any questions feel free to ask. 